### PR TITLE
Implement lazy init for OpenAIProvider

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -34,7 +34,8 @@ Import and instantiate the client, specifying the `provider_type`.
 from llm_factory_toolkit import LLMClient
 
 # Basic initialization for OpenAI, using default model (gpt-4o-mini)
-# Assumes OPENAI_API_KEY is in the environment or .env
+# Assumes OPENAI_API_KEY is in the environment or .env. If the key is missing,
+# initialization still succeeds but API calls will raise `ConfigurationError`.
 client = LLMClient(provider_type='openai')
 
 # Specify a model and API key directly

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A flexible Python toolkit designed to simplify interactions with various Large L
 *   **Structured Output:** Request responses in specific JSON formats, optionally validated using Pydantic models.
 *   **Async First:** Built with `asyncio` for non-blocking I/O operations.
 *   **Simplified Client:** High-level `LLMClient` manages provider instantiation, tool handling, and API calls.
-*   **Configuration:** Loads API keys securely from environment variables (`.env` file supported) or direct arguments.
+*   **Configuration:** Loads API keys securely from environment variables (`.env` file supported) or direct arguments. If a key isn't found, initialization succeeds but API calls will raise `ConfigurationError`.
 
 ## Installation
 
@@ -54,7 +54,9 @@ import os
 from llm_factory_toolkit import LLMClient
 from llm_factory_toolkit.exceptions import LLMToolkitError
 
-# Ensure your OPENAI_API_KEY is set in your environment or .env file
+# Ensure your OPENAI_API_KEY is set in your environment or .env file. If it is
+# missing, the client can still be created but any API call will raise
+# `ConfigurationError`.
 
 async def main():
     try:

--- a/tests/test_openai_lazy_init.py
+++ b/tests/test_openai_lazy_init.py
@@ -1,0 +1,25 @@
+import os
+
+import pytest
+
+from llm_factory_toolkit import LLMClient
+from llm_factory_toolkit.exceptions import ConfigurationError
+from llm_factory_toolkit.providers.openai_adapter import OpenAIProvider
+
+pytestmark = pytest.mark.asyncio
+
+
+def test_provider_initializes_without_key(monkeypatch):
+    """Provider can be created without an API key."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    provider = OpenAIProvider()
+    assert provider.async_client is None
+
+
+async def test_generate_fails_without_key(monkeypatch):
+    """Calling generate without a key raises ConfigurationError."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    client = LLMClient(provider_type="openai")
+    messages = [{"role": "user", "content": "hi"}]
+    with pytest.raises(ConfigurationError):
+        await client.generate(messages=messages)


### PR DESCRIPTION
## Summary
- avoid failure when OpenAI key is missing and warn instead
- add `_ensure_client` to check API key before use
- enforce key presence in `generate` and `generate_tool_intent`
- document new lazy init behaviour
- test provider and client without API key

## Testing
- `flake8 llm_factory_toolkit`
- `mypy llm_factory_toolkit`
- `pytest --cov=llm_factory_toolkit --cov-fail-under=80 tests/` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68753a5232d8832197e0be70b4037899