### PR TITLE
fix: migrate openai provider to responses api

### DIFF
--- a/llm_factory_toolkit/client.py
+++ b/llm_factory_toolkit/client.py
@@ -271,14 +271,19 @@ class LLMClient:
     ) -> List[Dict[str, Any]]:
         """
         Executes a list of tool call intents using the client's ToolFactory
-        and returns a list of formatted tool result messages *based on the content*.
-        This coroutine performs immediate execution and does not handle deferred payloads.
+        and returns a list of formatted tool result items suitable for the
+        OpenAI Responses API. Each executed tool produces an item of type
+        ``function_call_output`` that the caller can append to the conversation
+        history before making a follow-up LLM call. This coroutine performs
+        immediate execution and does not handle deferred payloads.
 
         Args:
             intent_output: The ToolIntentOutput containing tool_calls from the planner.
 
         Returns:
-            A list of tool result messages suitable for adding to an LLM conversation history.
+            A list of tool result items (each a ``dict`` with ``type`` set to
+            ``function_call_output``) ready to be appended to the conversation
+            history for subsequent LLM calls.
 
         Raises:
             ConfigurationError: If the client does not have a ToolFactory configured.
@@ -306,10 +311,9 @@ class LLMClient:
                 )
                 tool_result_messages.append(
                     {
-                        "role": "tool",
-                        "tool_call_id": tool_call_id,
-                        "name": tool_name,
-                        "content": json.dumps(
+                        "type": "function_call_output",
+                        "call_id": tool_call_id,
+                        "output": json.dumps(
                             {
                                 "error": f"Tool '{tool_name}' skipped due to argument parsing error during planning.",
                                 "details": tool_call.arguments_parsing_error,
@@ -340,10 +344,9 @@ class LLMClient:
                 )
                 tool_result_messages.append(
                     {
-                        "role": "tool",
-                        "tool_call_id": tool_call_id,
-                        "name": tool_name,
-                        "content": json.dumps(
+                        "type": "function_call_output",
+                        "call_id": tool_call_id,
+                        "output": json.dumps(
                             {
                                 "error": (
                                     "Internal error: Failed to serialize arguments for tool '%s'."
@@ -390,10 +393,9 @@ class LLMClient:
                     )
                 tool_result_messages.append(
                     {
-                        "role": "tool",
-                        "tool_call_id": tool_call_id,
-                        "name": tool_name,
-                        "content": result_content_for_llm,
+                        "type": "function_call_output",
+                        "call_id": tool_call_id,
+                        "output": result_content_for_llm,
                     }
                 )
             except Exception as e:
@@ -406,10 +408,9 @@ class LLMClient:
                 )
                 tool_result_messages.append(
                     {
-                        "role": "tool",
-                        "tool_call_id": tool_call_id,
-                        "name": tool_name,
-                        "content": json.dumps(
+                        "type": "function_call_output",
+                        "call_id": tool_call_id,
+                        "output": json.dumps(
                             {
                                 "error": f"Unexpected client-side error executing tool '{tool_name}'.",
                                 "details": str(e),

--- a/llm_factory_toolkit/providers/openai_adapter.py
+++ b/llm_factory_toolkit/providers/openai_adapter.py
@@ -10,9 +10,8 @@ from openai import (
     AsyncOpenAI,
     BadRequestError,
     RateLimitError,
-    pydantic_function_tool,
 )
-from pydantic import BaseModel, Field, create_model
+from pydantic import BaseModel
 
 from ..exceptions import (
     ConfigurationError,
@@ -153,33 +152,24 @@ class OpenAIProvider(BaseProvider):
         current_messages = list(input)
         iteration_count = 0
 
-        api_call_args = {"model": active_model, **kwargs}  # Start with base args
+        api_call_args = {"model": active_model, **kwargs}
         use_parse = False
 
-        # --- Handle response_format ---
         if response_format:
-            if isinstance(response_format, type) and issubclass(
-                response_format, BaseModel
-            ):
+            if isinstance(response_format, type) and issubclass(response_format, BaseModel):
                 api_call_args["text_format"] = response_format
                 use_parse = True
-            elif isinstance(response_format, dict):
-                api_call_args["text"] = response_format
+            else:
+                api_call_args["text"] = {"format": response_format}
 
-        # --- Optional parameters ---
         if temperature is not None:
             api_call_args["temperature"] = temperature
         if max_output_tokens is not None:
             api_call_args["max_output_tokens"] = max_output_tokens
 
-        # --- Main Generation Loop ---
         while iteration_count < max_tool_iterations:
-            request_payload = {
-                **api_call_args,
-                "input": current_messages,
-            }  # Combine base args + current messages
+            request_payload = {**api_call_args, "input": current_messages}
 
-            # --- Tool Configuration ---
             tools_for_payload, tool_choice_for_payload = self._prepare_tool_payload(
                 use_tools, request_payload
             )
@@ -188,66 +178,35 @@ class OpenAIProvider(BaseProvider):
             if tool_choice_for_payload is not None:
                 request_payload["tool_choice"] = tool_choice_for_payload
 
-            # --- API Call ---
             completion = await self._make_api_call(
-                request_payload,
-                active_model,
-                len(current_messages),
+                request_payload, active_model, len(current_messages)
             )
 
-            assistant_text = ""
-            tool_calls: List[Any] = []
-            for item in getattr(completion, "output", []):
-                if getattr(item, "type", None) == "message" and getattr(
-                    item, "content", None
-                ):
-                    parts = [
-                        getattr(c, "text", "")
-                        for c in item.content
-                        if getattr(c, "type", "") == "output_text"
-                    ]
-                    assistant_text += "".join(parts)
-                elif getattr(item, "type", None) in {
-                    "function_call",
-                    "custom_tool_call",
-                }:
-                    tool_calls.append(item)
+            assistant_text = getattr(completion, "output_text", "") or ""
+            tool_calls = [
+                item
+                for item in getattr(completion, "output", [])
+                if getattr(item, "type", None) in {"function_call", "custom_tool_call"}
+            ]
 
-            response_message_dict: Dict[str, Any] = {
-                "role": "assistant",
-                "content": assistant_text,
-            }
-            if tool_calls:
-                response_message_dict["tool_calls"] = [
-                    {
-                        "id": getattr(tc, "id", None) or getattr(tc, "call_id", ""),
-                        "type": "function",
-                        "function": {
-                            "name": getattr(tc, "name", ""),
-                            "arguments": getattr(
-                                tc, "arguments", getattr(tc, "input", "")
-                            ),
-                        },
-                    }
-                    for tc in tool_calls
-                ]
-            current_messages.append(response_message_dict)
+            new_items = []
+            for out_item in getattr(completion, "output", []):
+                dump = out_item.model_dump()
+                if dump.get("type") in {"function_call", "custom_tool_call"}:
+                    dump.pop("parsed_arguments", None)
+                new_items.append(dump)
+            current_messages.extend(new_items)
 
             if not tool_calls:
-                if use_parse and getattr(completion, "output", None):
-                    first = completion.output[0]
-                    if (
-                        getattr(first, "content", None)
-                        and getattr(first.content[0], "parsed", None) is not None
-                    ):
-                        return first.content[0].parsed, collected_payloads
+                if use_parse:
+                    for item in getattr(completion, "output", []):
+                        for content in getattr(item, "content", []):
+                            parsed_obj = getattr(content, "parsed", None)
+                            if parsed_obj is not None:
+                                return parsed_obj, collected_payloads
 
-                final_content = assistant_text or getattr(
-                    completion, "output_text", None
-                )
-                if isinstance(response_format, dict) and response_format.get(
-                    "format", ""
-                ).startswith("json"):
+                final_content = assistant_text
+                if isinstance(response_format, dict) and response_format.get("type", "").startswith("json"):
                     if final_content:
                         try:
                             _ = json.loads(final_content)
@@ -282,13 +241,12 @@ class OpenAIProvider(BaseProvider):
             collected_payloads.extend(payloads)
             iteration_count += 1
             module_logger.debug(
-                f"Completed tool iteration {iteration_count}. Current messages: {[m['role'] for m in current_messages]}"
+                "Completed tool iteration %s. Current messages: %s",
+                iteration_count,
+                [m.get('role') or m.get('type') for m in current_messages],
             )
 
-        # --- Max Iterations Reached ---
-        final_content = self._aggregate_final_content(
-            current_messages, max_tool_iterations
-        )
+        final_content = self._aggregate_final_content(current_messages, max_tool_iterations)
         return final_content, collected_payloads
 
     async def generate_tool_intent(
@@ -308,13 +266,11 @@ class OpenAIProvider(BaseProvider):
         use_parse = False
 
         if response_format:
-            if isinstance(response_format, type) and issubclass(
-                response_format, BaseModel
-            ):
+            if isinstance(response_format, type) and issubclass(response_format, BaseModel):
                 api_call_args["text_format"] = response_format
                 use_parse = True
-            elif isinstance(response_format, dict):
-                api_call_args["text"] = response_format
+            else:
+                api_call_args["text"] = {"format": response_format}
 
         if temperature is not None:
             api_call_args["temperature"] = temperature
@@ -323,51 +279,31 @@ class OpenAIProvider(BaseProvider):
 
         request_payload = {**api_call_args, "input": list(input)}
 
-        # --- Tool Configuration (using refactored logic) ---
         tools_for_payload, tool_choice_for_payload = self._prepare_tool_payload(
-            use_tools, kwargs
+            use_tools, request_payload
         )
         if tools_for_payload is not None:
             request_payload["tools"] = tools_for_payload
         if tool_choice_for_payload is not None:
             request_payload["tool_choice"] = tool_choice_for_payload
-        # --- End Tool Configuration ---
 
         completion = await self._make_api_call(
             request_payload, active_model, len(input)
         )
 
-        assistant_text = ""
-        tool_call_items: List[Any] = []
-        for item in getattr(completion, "output", []):
-            if getattr(item, "type", None) == "message" and getattr(
-                item, "content", None
-            ):
-                parts = [
-                    getattr(c, "text", "")
-                    for c in item.content
-                    if getattr(c, "type", "") == "output_text"
-                ]
-                assistant_text += "".join(parts)
-            elif getattr(item, "type", None) in {"function_call", "custom_tool_call"}:
-                tool_call_items.append(item)
+        assistant_text = getattr(completion, "output_text", "") or ""
+        tool_call_items = [
+            item
+            for item in getattr(completion, "output", [])
+            if getattr(item, "type", None) in {"function_call", "custom_tool_call"}
+        ]
 
-        raw_assistant_msg_dict: Dict[str, Any] = {
-            "role": "assistant",
-            "content": assistant_text,
-        }
-        if tool_call_items:
-            raw_assistant_msg_dict["tool_calls"] = [
-                {
-                    "id": getattr(tc, "id", None) or getattr(tc, "call_id", ""),
-                    "type": "function",
-                    "function": {
-                        "name": getattr(tc, "name", ""),
-                        "arguments": getattr(tc, "arguments", getattr(tc, "input", "")),
-                    },
-                }
-                for tc in tool_call_items
-            ]
+        raw_assistant_items: List[Dict[str, Any]] = []
+        for item in getattr(completion, "output", []):
+            if getattr(item, "type", None) in {"function_call", "custom_tool_call"}:
+                dump = item.model_dump()
+                dump.pop("parsed_arguments", None)
+                raw_assistant_items.append(dump)
 
         parsed_tool_calls_list: List[ParsedToolCall] = []
         if tool_call_items:
@@ -377,6 +313,8 @@ class OpenAIProvider(BaseProvider):
                 args_str = getattr(tc, "arguments", getattr(tc, "input", None))
                 if func_name and self.tool_factory:
                     self.tool_factory.increment_tool_usage(func_name)
+
+                call_identifier = getattr(tc, "call_id", None) or getattr(tc, "id", None)
 
                 args_dict_or_str: Union[Dict[str, Any], str]
                 parsing_error: Optional[str] = None
@@ -403,21 +341,24 @@ class OpenAIProvider(BaseProvider):
 
                 parsed_tool_calls_list.append(
                     ParsedToolCall(
-                        id=str(getattr(tc, "id", "")),
+                        id=str(call_identifier or ""),
                         name=func_name or "",
                         arguments=args_dict_or_str,
                         arguments_parsing_error=parsing_error,
                     )
                 )
 
-        if use_parse and getattr(completion, "output", None):
-            first = completion.output[0]
-            if (
-                getattr(first, "content", None)
-                and getattr(first.content[0], "parsed", None) is not None
-            ):
-                content_val = first.content[0].parsed.model_dump_json()
-            else:
+        if use_parse:
+            content_val = ""
+            for item in getattr(completion, "output", []):
+                for content in getattr(item, "content", []):
+                    parsed_obj = getattr(content, "parsed", None)
+                    if parsed_obj is not None:
+                        content_val = parsed_obj.model_dump_json()
+                        break
+                if content_val:
+                    break
+            if not content_val:
                 content_val = assistant_text
         else:
             content_val = assistant_text
@@ -425,7 +366,7 @@ class OpenAIProvider(BaseProvider):
         return ToolIntentOutput(
             content=content_val,
             tool_calls=parsed_tool_calls_list if parsed_tool_calls_list else None,
-            raw_assistant_message=raw_assistant_msg_dict,
+            raw_assistant_message=raw_assistant_items,
         )
 
     def _prepare_tool_payload(
@@ -458,41 +399,21 @@ class OpenAIProvider(BaseProvider):
 
         tools_payload = None
         if final_tool_definitions:
-            converted_tools: List[Any] = []
+            converted_tools: List[Dict[str, Any]] = []
             for tool in final_tool_definitions:
-                func = tool.get("function") if tool.get("type") == "function" else None
-                if func:
-                    params_schema = func.get("parameters", {})
-                    properties = params_schema.get("properties", {})
-                    required = set(params_schema.get("required", []))
-                    model_name = f"{func.get('name', 'Tool')}Params"
-                    if properties:
-                        type_map = {
-                            "string": str,
-                            "integer": int,
-                            "number": float,
-                            "boolean": bool,
-                            "array": list,
-                            "object": dict,
-                        }
-                        ParamModel = create_model(
-                            model_name,
-                            **{
-                                name: (
-                                    type_map.get(prop.get("type"), Any),
-                                    Field(default=... if name in required else None),
-                                )
-                                for name, prop in properties.items()
-                            },
-                        )  # type: ignore[call-overload]
-                    else:
-                        ParamModel = create_model(model_name)
+                if tool.get("type") == "function":
+                    func = tool.get("function", {})
+                    params = func.get("parameters", {}) or {}
+                    if params and "additionalProperties" not in params:
+                        params = {**params, "additionalProperties": False}
                     converted_tools.append(
-                        pydantic_function_tool(
-                            ParamModel,
-                            name=func.get("name"),
-                            description=func.get("description"),
-                        )
+                        {
+                            "type": "function",
+                            "name": func.get("name"),
+                            "description": func.get("description"),
+                            "parameters": params,
+                            "strict": func.get("strict", True),
+                        }
                     )
                 else:
                     converted_tools.append(tool)
@@ -598,13 +519,11 @@ class OpenAIProvider(BaseProvider):
                 if getattr(call, "function", None):
                     func_name = getattr(call.function, "name", None)
                     func_args_str = getattr(call.function, "arguments", None)
-                    call_id = getattr(call, "id", None)
+                    call_id = getattr(call, "call_id", None) or getattr(call, "id", None)
                 else:
                     func_name = getattr(call, "name", None)
                     func_args_str = getattr(call, "arguments", None)
-                    call_id = getattr(call, "id", None) or getattr(
-                        call, "call_id", None
-                    )
+                    call_id = getattr(call, "call_id", None) or getattr(call, "id", None)
             elif getattr(call, "type", None) == "custom_tool_call":
                 func_name = getattr(call, "name", None)
                 func_args_str = getattr(call, "input", None)
@@ -623,10 +542,9 @@ class OpenAIProvider(BaseProvider):
                     f"Malformed tool call received: ID={call_id}, Name={func_name}, Args={func_args_str}"
                 )
                 return {
-                    "role": "tool",
-                    "tool_call_id": call_id or "unknown",
-                    "name": func_name or "unknown",
-                    "content": json.dumps(
+                    "type": "function_call_output",
+                    "call_id": call_id or "unknown",
+                    "output": json.dumps(
                         {"error": "Malformed tool call received by client."}
                     ),
                 }, None
@@ -650,10 +568,9 @@ class OpenAIProvider(BaseProvider):
                 )
 
                 return {
-                    "role": "tool",
-                    "tool_call_id": call_id,
-                    "name": func_name,
-                    "content": tool_exec_result.content,
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": tool_exec_result.content,
                 }, payload
 
             except ToolError as e:
@@ -661,10 +578,9 @@ class OpenAIProvider(BaseProvider):
                     f"Error processing tool call {call_id} ({func_name}): {e}"
                 )
                 return {
-                    "role": "tool",
-                    "tool_call_id": call_id,
-                    "name": func_name,
-                    "content": json.dumps({"error": str(e)}),
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": json.dumps({"error": str(e)}),
                 }, None
             except Exception as e:
                 module_logger.error(
@@ -672,10 +588,9 @@ class OpenAIProvider(BaseProvider):
                     exc_info=True,
                 )
                 return {
-                    "role": "tool",
-                    "tool_call_id": call_id,
-                    "name": func_name,
-                    "content": json.dumps(
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": json.dumps(
                         {"error": f"Unexpected client-side error handling tool: {e}"}
                     ),
                 }, None
@@ -700,11 +615,25 @@ class OpenAIProvider(BaseProvider):
         """Return assistant content when max iterations reached."""
         final_content = None
         for m in reversed(current_messages):
-            if m.get("role") == "assistant" and m.get("content"):
+            if m.get("role") == "assistant" and isinstance(m.get("content"), str) and m.get("content"):
                 warning_msg = (
                     f"\n\n[Warning: Max tool iterations ({max_tool_iterations}) reached. "
                     "Result might be incomplete.]"
                 )
                 final_content = str(m.get("content", "")) + warning_msg
                 break
+            if m.get("type") == "message" and m.get("role") == "assistant":
+                parts = m.get("content", [])
+                text_accum = ""
+                if isinstance(parts, list):
+                    for p in parts:
+                        if isinstance(p, dict) and p.get("type") in {"output_text", "text"}:
+                            text_accum += p.get("text", "")
+                if text_accum:
+                    warning_msg = (
+                        f"\n\n[Warning: Max tool iterations ({max_tool_iterations}) reached. "
+                        "Result might be incomplete.]"
+                    )
+                    final_content = text_accum + warning_msg
+                    break
         return final_content

--- a/llm_factory_toolkit/tools/models.py
+++ b/llm_factory_toolkit/tools/models.py
@@ -1,7 +1,7 @@
 # llm_factory_toolkit/llm_factory_toolkit/tools/models.py
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 # --- Existing models ---
@@ -21,9 +21,10 @@ class ToolIntentOutput(BaseModel):
         None  # Text content if LLM replied directly without a tool call
     )
     tool_calls: Optional[List[ParsedToolCall]] = None  # List of parsed tool calls
-    raw_assistant_message: Dict[
-        str, Any
-    ]  # The full, raw message object from the assistant
+    raw_assistant_message: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="Raw output items from the assistant (e.g., function_call items)",
+    )
 
 
 class ToolExecutionResult(BaseModel):

--- a/tests/test_llmcall_tool_intent.py
+++ b/tests/test_llmcall_tool_intent.py
@@ -30,7 +30,10 @@ Your task is to retrieve three separate parts of a master access code using the 
 Once you have all three parts, combine them in the exact order: Part 1, Part 2, Part 3.
 Present the final combined code clearly.
 """
-USER_PROMPT_MULTI_TOOL = "Please retrieve the master access code. Use 'source_A' for part 1, 'key_B' for part 2, and 'vault_C' for part 3, then combine them."
+USER_PROMPT_MULTI_TOOL = (
+    "Please retrieve the master access code. Use 'source_A' for part 1, "
+    "'key_B' for part 2, and 'vault_C' for part 3, then combine them."
+)
 
 TEST_MODEL = "gpt-4o-mini"  # Model known to handle parallel tool calls well
 
@@ -204,7 +207,7 @@ async def test_openai_three_tool_calls_combined_secret():
         ]
 
         # 4. Make API call to retrieve tools
-        print(f"Calling client.generate_tool_intent (Planner)")
+        print("Calling client.generate_tool_intent (Planner)")
         intent_output: ToolIntentOutput = await client.generate_tool_intent(
             input=messages,
             model=TEST_MODEL,
@@ -215,7 +218,7 @@ async def test_openai_three_tool_calls_combined_secret():
         print(f"Planner output:\n{intent_output.model_dump_json(indent=2)}")
         # Add the planner's turn (which contains the tool_calls structure)
         if intent_output.raw_assistant_message:
-            messages.append(intent_output.raw_assistant_message)
+            messages.extend(intent_output.raw_assistant_message)
 
         # Minimal check on planner output to ensure we can proceed
         if not intent_output.tool_calls or len(intent_output.tool_calls) == 0:
@@ -254,7 +257,7 @@ async def test_openai_three_tool_calls_combined_secret():
         # Add the tool results
         messages.extend(tool_result_messages)
 
-        print(f"Calling client.generate (Explainer)")
+        print("Calling client.generate (Explainer)")
         final_response_content, _ = await client.generate(
             input=messages,
             model=TEST_MODEL,


### PR DESCRIPTION
## Summary
- switch OpenAI provider to Responses API with `input` items and parsed `output`
- convert tool definitions to new format and enforce `additionalProperties: false`
- handle function call outputs via call IDs and remove parsed artifacts
- align tool intent execution and planning with Responses API items

## Testing
- `flake8 llm_factory_toolkit/ tests/test_llmcall_tool_intent.py`
- `mypy llm_factory_toolkit/`
- `pytest tests/test_llmcall_tool_intent.py::test_openai_three_tool_calls_combined_secret -vv`
- `pytest tests/test_llmcall_custom_tool_class.py::test_openai_custom_tool_class_call -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b9f5cd6bfc8321a7459bc1927eea3f