### PR TITLE
Add OpenAI file search integration

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -297,6 +297,12 @@ news_run = await client.generate(
 
 # Passing a dictionary to ``web_search`` enables provider-specific options,
 # such as disabling citation links while keeping search enabled.
+
+# Provide vector stores for OpenAI's hosted file search tool during generation
+briefing = await client.generate(
+    input=history,
+    file_search={"vector_store_ids": ["vs_product_docs"], "max_num_results": 5},
+)
 ```
 
 If you need to inspect the complete provider transcript (including hidden tool

--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ news_result = await client.generate(
 
 # web_search accepts structured options. Here we keep search enabled but
 # strip citation hyperlinks from the model's response.
+
+# Expose OpenAI's hosted file search tool backed by your vector stores
+research_result = await client.generate(
+    input=[{"role": "user", "content": "Summarise the launch checklist."}],
+    file_search={"vector_store_ids": ["vs_launch_docs"], "max_num_results": 3},
+)
 ```
 
 ## Reasoning Models

--- a/llm_factory_toolkit/providers/base.py
+++ b/llm_factory_toolkit/providers/base.py
@@ -5,7 +5,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterator, List, Optional, Type
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Type
 
 from dotenv import load_dotenv
 from pydantic import BaseModel
@@ -137,6 +137,7 @@ class BaseProvider(ABC):
         tool_execution_context: Optional[Dict[str, Any]] = None,
         mock_tools: bool = False,
         web_search: bool | Dict[str, Any] = False,
+        file_search: bool | Dict[str, Any] | List[str] | Tuple[str, ...] = False,
         **kwargs: Any,
     ) -> GenerationResult:
         """
@@ -165,6 +166,11 @@ class BaseProvider(ABC):
                 for this request when available. Provide a dictionary (for
                 example ``{"citations": False}``) to customise provider
                 behaviour such as disabling citations.
+            file_search: Whether to expose the provider's built-in file search
+                tool. Provide a list of vector store identifiers or a
+                dictionary containing ``vector_store_ids`` and optional search
+                configuration (for example ``{"vector_store_ids": ["vs_123"],
+                "max_num_results": 4}``).
         """
         pass
 
@@ -179,6 +185,7 @@ class BaseProvider(ABC):
         max_output_tokens: Optional[int] = None,
         response_format: Optional[Dict[str, Any] | Type[BaseModel]] = None,
         web_search: bool | Dict[str, Any] = False,
+        file_search: bool | Dict[str, Any] | List[str] | Tuple[str, ...] = False,
         **kwargs: Any,
     ) -> ToolIntentOutput:
         """
@@ -199,6 +206,10 @@ class BaseProvider(ABC):
                 for the intent planning request when available. Provide a
                 dictionary (for example ``{"citations": False}``) to customise
                 provider behaviour such as disabling citations.
+            file_search: Whether to expose the provider's built-in file search
+                tool while planning tool calls. Provide a list of vector store
+                identifiers or a dictionary containing ``vector_store_ids`` and
+                optional retrieval configuration.
             **kwargs: Additional provider-specific arguments.
 
         Returns:

--- a/tests/test_merge_history.py
+++ b/tests/test_merge_history.py
@@ -29,12 +29,14 @@ class _RecordingProvider(BaseProvider):
         tool_execution_context: Optional[Dict[str, Any]] = None,
         mock_tools: bool = False,
         web_search: Any = False,
+        file_search: Any = False,
         **kwargs: Any,
     ) -> GenerationResult:
         self.last_messages = copy.deepcopy(input)
         self.last_kwargs = {
             "tool_execution_context": tool_execution_context,
             "web_search": web_search,
+            "file_search": file_search,
             **kwargs,
         }
         return GenerationResult(content=None)
@@ -49,6 +51,7 @@ class _RecordingProvider(BaseProvider):
         max_output_tokens: Optional[int] = None,
         response_format: Optional[Dict[str, Any] | Type[Any]] = None,
         web_search: bool = False,
+        file_search: bool = False,
         **kwargs: Any,
     ) -> Any:
         raise NotImplementedError


### PR DESCRIPTION
## Summary
- add OpenAI file search configuration support including validation, payload wiring, and improved URL stripping for citation cleanup
- expose the new file_search option through the shared BaseProvider and LLMClient interfaces
- document the workflow updates and extend the test suite to cover file search behaviour and forwarding

## Testing
- pytest tests/test_openai_web_search.py tests/test_merge_history.py

------
https://chatgpt.com/codex/tasks/task_e_68e685a0e00083218dd16f2b627fad91